### PR TITLE
Fix KPackageStructure deprecation

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,4 +1,5 @@
 {
+    "KPackageStructure": "Plasma/Applet",
     "KPlugin": {
         "Authors": [
             {
@@ -12,9 +13,6 @@
         "Id": "org.kde.windowtitle",
         "License": "GPLv2",
         "Name": "Window Title",
-        "ServiceTypes": [
-            "Plasma/Applet"
-        ],
         "Version": "0.7.1",
         "Website": "https://github.com/psifidotos/applet-window-title"
     },


### PR DESCRIPTION
This warning comes up on in the log of the plasmashell without this change:
```
KPackageStructure of KPluginMetaData(pluginId:"org.kde.windowtitle", fileName: "/usr/share/plasma/plasmoids/org.kde.windowtitle/metadata.json") does not match requested format "Plasma/Applet"
```

https://develop.kde.org/docs/plasma/widget/porting_kf6/#porting-an-existing-plasmoid also says

> the KPlugin section may still contain the ServiceTypes key. This needs to be replaced by a KPackageStructure entry in the json's top level.